### PR TITLE
Feature/translatable

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -48,18 +48,18 @@ There are really 5 steps to setting it up with your projects.
 your objects_list:
    
     <tr>
-       <th>{% anchor first_name Name %}</th>
-       <th>{% anchor creation_date Creation %}</th>
+       <th>{% sort_anchor "first_name" "Name" %}</th>
+       <th>{% sort_anchor "creation_date" _("Creation") %}</th>
         ...
     </tr>
 
     The first argument is a field of the objects list, and the second 
-    one(optional) is a title that would be displayed. The previous 
-    snippet will be rendered like this:
+    one(optional) is a title that would be displayed. Both arguments can be 
+    be context variables. The previous snippet will be rendered like this:
 
     <tr>
         <th><a href="/path/to/your/view/?sort=first_name" title="Name">Name</a></th>
-        <th><a href="/path/to/your/view/?sort=creation_date" title="Name">Creation</a></th>
+        <th><a href="/path/to/your/view/?sort=creation_date" title="Name">Erstellungsdatum</a></th>
         ...
     </tr>
 

--- a/django_sorting/templatetags/sorting_tags.py
+++ b/django_sorting/templatetags/sorting_tags.py
@@ -17,6 +17,8 @@ sort_directions = {
 
 def anchor(parser, token):
     """
+    depreciated: will be removed in a later version
+    
     Parses a tag that's supposed to be in this format: {% anchor field title %}    
     """
     bits = [b.strip('"\'') for b in token.split_contents()]
@@ -26,11 +28,13 @@ def anchor(parser, token):
         title = bits[2]
     except IndexError:
         title = bits[1].capitalize()
-    return SortAnchorNode(bits[1].strip(), title.strip())
+    return OldSortAnchorNode(bits[1].strip(), title.strip())
     
 
-class SortAnchorNode(template.Node):
+class OldSortAnchorNode(template.Node):
     """
+    depreciated: will be removed in a later version
+    
     Renders an <a> HTML tag with a link which href attribute 
     includes the field on which we sort and the direction.
     and adds an up or down arrow if the field is the one 
@@ -76,6 +80,68 @@ class SortAnchorNode(template.Node):
         return '<a href="%s" title="%s">%s</a>' % (url, self.title, title)
 
 
+def sort_anchor(parser, token):
+    """
+    Parses a tag that's supposed to be in this format: {% sort_anchor "field" "title" %}
+    """
+    bits = token.split_contents()
+    if len(bits) < 2:
+        raise TemplateSyntaxError, "anchor tag takes at least 1 argument"
+    try:
+        title = bits[2]
+    except IndexError:
+        title = bits[1].capitalize()
+    return SortAnchorNode(bits[1].strip(), title.strip())
+
+class SortAnchorNode(template.Node):
+    """
+    Renders an <a> HTML tag with a link which href attribute 
+    includes the field on which we sort and the direction.
+    and adds an up or down arrow if the field is the one 
+    currently being sorted on.
+
+    Eg.
+        {% anchor "name" "Name" %} generates
+        <a href="/the/current/path/?sort=name" title="Name">Name</a>
+
+    """
+    def __init__(self, field, title):
+        self.field = template.Variable(field)
+        self.title = template.Variable(title)
+
+    def render(self, context):
+        request = context['request']
+        getvars = request.GET.copy()
+        field = self.field.resolve(context)
+        title = self.title.resolve(context)
+        if 'sort' in getvars:
+            sortby = getvars['sort']
+            del getvars['sort']
+        else:
+            sortby = ''
+        if 'dir' in getvars:
+            sortdir = getvars['dir']
+            del getvars['dir']
+        else:
+            sortdir = ''
+        if sortby == field:
+            getvars['dir'] = sort_directions[sortdir]['inverse']
+            icon = sort_directions[sortdir]['icon']
+        else:
+            icon = ''
+        if len(getvars.keys()) > 0:
+            urlappend = "&%s" % getvars.urlencode()
+        else:
+            urlappend = ''
+        if icon:
+            title_with_sort_ordering = "%s %s" % (title, icon)
+        else:
+            title_with_sort_ordering = title
+
+        url = '%s?sort=%s%s' % (request.path, field, urlappend)
+        return '<a href="%s" title="%s">%s</a>' % (url, title, title_with_sort_ordering)
+
+
 def autosort(parser, token):
     bits = [b.strip('"\'') for b in token.split_contents()]
     if len(bits) != 2:
@@ -108,5 +174,6 @@ class SortedDataNode(template.Node):
         return ''
 
 anchor = register.tag(anchor)
+sort_anchor = register.tag(sort_anchor)
 autosort = register.tag(autosort)
 


### PR DESCRIPTION
I added a new `sort_anchor` templatetag that supports context variables. This makes some new things possible:
e.g

```
{% sort_anchor "myfiled" _("My Translated Title") %}
```

or

```
{% for field in fields %}
    {% sort_anchor field.name field.title %}
{% endfor %}
```

I've left the `anchor` templatetag in place for now for backwards compatibility. The new tag also has a smaller chance of creating conflicts with other templatetag libraries.
