### PR TITLE
Added translation feature to sort title : _("some title")

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -48,13 +48,13 @@ There are really 5 steps to setting it up with your projects.
 your objects_list:
    
     <tr>
-       <th>{% anchor first_name Name %}</th>
-       <th>{% anchor creation_date Creation %}</th>
+       <th>{% anchor "first_name" "Name" %}</th>
+       <th>{% anchor "creation_date" _("Creation") %}</th>
         ...
     </tr>
 
     The first argument is a field of the objects list, and the second 
-    one(optional) is a title that would be displayed. The previous 
+    one(optional) is a title that would be displayed, you can use django translation syntax _("") for the second argument. The previous 
     snippet will be rendered like this:
 
     <tr>

--- a/README.txt
+++ b/README.txt
@@ -54,7 +54,8 @@ your objects_list:
     </tr>
 
     The first argument is a field of the objects list, and the second 
-    one(optional) is a title that would be displayed, you can use django translation syntax _("") for the second argument. The previous 
+    one(optional) is a title that would be displayed, you can use 
+    django translation syntax _("") for the second argument. The previous 
     snippet will be rendered like this:
 
     <tr>

--- a/django_sorting/templatetags/sorting_tags.py
+++ b/django_sorting/templatetags/sorting_tags.py
@@ -72,7 +72,7 @@ class SortAnchorNode(template.Node):
         if icon:
             title_icon = u"%s %s" % (title, icon)
         else:
-            title_icon = self.title
+            title_icon = title
 
         url = '%s?sort=%s%s' % (request.path, field, urlappend)
         return u'<a href="%s" title="%s">%s</a>' % (url, title, title_icon)


### PR DESCRIPTION
The default django-sorting implementation does not support django translation, for example,  _("some ttitle"), I've made some slight modifications to support this feature.

Example:

``` python
{% anchor "creation_date" _("Creation") %}
```

see : https://github.com/jetli/django-sorting
